### PR TITLE
DRY flashes and support Rails 4.1 for flashes

### DIFF
--- a/app/views/partials/_surveyor_flashes.html.haml
+++ b/app/views/partials/_surveyor_flashes.html.haml
@@ -1,4 +1,4 @@
-- types = flash.keys.map(&:to_sym).select { |k| [:notice, :error, :warning].include?(k) }
+- types = flash.keys.map(&:to_sym) & [:notice, :error, :warning]
 - if types.any?
   .surveyor_flash
     = flash_messages(types)

--- a/app/views/partials/_surveyor_flashes.html.haml
+++ b/app/views/partials/_surveyor_flashes.html.haml
@@ -1,0 +1,5 @@
+- types = flash.keys.map(&:to_sym).select { |k| [:notice, :error, :warning].include?(k) }
+- if types.any?
+  .surveyor_flash
+    = flash_messages(types)
+    .close

--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -1,8 +1,5 @@
 #surveyor
-  - unless (types = flash.keys.select{|k| [:notice, :error, :warning].include?(k)}).blank?
-    .surveyor_flash
-      = flash_messages(types)
-      .close
+  = render "partials/surveyor_flashes"
   = semantic_form_for(@response_set, :as => :r, :url => surveyor.update_my_survey_path, :html => {:method => :put, :id => "survey_form", :class => @survey.custom_class}) do |f|
 
     = hidden_field_tag :surveyor_javascript_enabled, false

--- a/app/views/surveyor/new.html.haml
+++ b/app/views/surveyor/new.html.haml
@@ -1,8 +1,5 @@
 #surveyor
-  - unless (types = flash.keys.select{|k| [:notice, :error, :warning].include?(k)}).blank?
-    .surveyor_flash
-      = flash_messages(types)
-      .close
+  = render "partials/surveyor_flashes"
   .survey_title= t('surveyor.take_these_surveys')
   %br
   #survey_list

--- a/app/views/surveyor/show.html.haml
+++ b/app/views/surveyor/show.html.haml
@@ -1,8 +1,5 @@
 #surveyor
-  - unless (types = flash.keys.select{|k| [:notice, :error, :warning].include?(k)}).blank?
-    .surveyor_flash
-      = flash_messages(types)
-      .close
+  = render "partials/surveyor_flashes"
   = semantic_form_for(@response_set, :as => :r, :url => surveyor.update_my_survey_path, :html => {:id => "survey_form", :class => @survey.custom_class}) do |f|
     .survey_title= @survey.title
     - @survey.sections.each do |section|


### PR DESCRIPTION
Rails 4.1 normalizes flash keys as strings, so we need to make sure they're symbols
to compare them to the allowed values.

Also, is this the best way to manage the fork, by putting everything in master?